### PR TITLE
Removing the unused const variable

### DIFF
--- a/source/internal/database.c
+++ b/source/internal/database.c
@@ -31,7 +31,7 @@
 #define DECOMPOSE_INDEX1_SHIFT (12)
 #define DECOMPOSE_INDEX2_SHIFT (5)
 
-static const unicode_t DECOMPOSE_INDEX1_MASK = MAX_LEGAL_UNICODE;
+/* static const unicode_t DECOMPOSE_INDEX1_MASK = MAX_LEGAL_UNICODE; */
 static const unicode_t DECOMPOSE_INDEX2_MASK = (1 << DECOMPOSE_INDEX1_SHIFT) - 1;
 static const unicode_t DECOMPOSE_DATA_MASK = (1 << DECOMPOSE_INDEX2_SHIFT) - 1;
 


### PR DESCRIPTION
‘DECOMPOSE_INDEX1_MASK’ is defined but not used. Causing the compilation error in z-data haskell library.

```
third_party/utf8rewind/source/internal/database.c:34:24: error:
     warning: ‘DECOMPOSE_INDEX1_MASK’ defined but not used [-Wunused-const-variable=]
       34 | static const unicode_t DECOMPOSE_INDEX1_MASK = MAX_LEGAL_UNICODE;
          |                        ^~~~~~~~~~~~~~~~~~~~~
   |
34 | static const unicode_t DECOMPOSE_INDEX1_MASK = MAX_LEGAL_UNICODE;
   |     
```

This PR just merely comment out the line.